### PR TITLE
feat: support rollup >=1.20.0 as peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "barebone-ts",
-  "version": "1.0.0",
+  "name": "rollup-plugin-string-import",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "barebone-ts",
-      "version": "1.0.0",
+      "name": "rollup-plugin-string-import",
+      "version": "1.2.5",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@rollup/pluginutils": "^5.1.0"
@@ -29,7 +29,7 @@
         "typescript": "^5.5.2"
       },
       "peerDependencies": {
-        "rollup": "4.20.0"
+        "rollup": ">=1.20.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@rollup/pluginutils": "^5.1.0"
   },
   "peerDependencies": {
-    "rollup": "4.20.0"
+    "rollup": ">=1.20.0"
   },
   "files": [
     "dist/*"


### PR DESCRIPTION
Changed the `rollup` peer dependency version from `4.20.0` to `>=1.20.0` to align with [`README.md`](https://github.com/ExposedCat/rollup-plugin-string-import/blob/face5678ee214b415d9c16fedb08c0d635618046/README.md?plain=1#L16)

This PR will address #3 and #2 and many other versions. (In my case, I am still using rollup v3)